### PR TITLE
python-rapidjson 1.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ test:
   requires:
     - pip
     - pytest
+    - pytz
   source_files:
     - tests
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,9 @@ source:
 
 build:
   number: 0
-  skip: True  # [py36]
+  # This package isn't included in the SOW Packages.
+  # Also there isn't rapidjson==1.1.0 on s390x
+  skip: True  # [py36 or s390x]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,13 +34,8 @@ test:
     - rapidjson
   requires:
     - pip
-    - pytest
-    - pytz
-  source_files:
-    - tests
   commands:
     - pip check
-    - pytest tests
 
 about:
   home: https://github.com/python-rapidjson/python-rapidjson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,14 +20,12 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-
   host:
     - python
     - pip
     - wheel
     - setuptools
     - rapidjson =={{ rapidjson_version }}
-
   run:
     - python
 
@@ -36,8 +34,12 @@ test:
     - rapidjson
   requires:
     - pip
+    - pytest
+  source_files:
+    - tests
   commands:
     - pip check
+    - pytest tests
 
 about:
   home: https://github.com/python-rapidjson/python-rapidjson

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "python-rapidjson" %}
-{% set version = "1.4" %}
-{% set sha256 = "018c20d3983cccfdc9cfed64407d4ba861ef3d64fe324a486f7130431afdefa7" %}
+{% set version = "1.5" %}
+{% set sha256 = "04323e63cf57f7ed927fd9bcb1861ef5ecb0d4d7213f2755969d4a1ac3c2de6f" %}
 {% set rapidjson_version = "1.1.0" %}
 
 package:


### PR DESCRIPTION
Update python-rapidjson to 1.5

Version change: bump version number from 1.4 to 1.5
Bug Tracker: new open issues https://github.com/python-rapidjson/python-rapidjson/issues
Upstream license:  License file:  https://github.com/python-rapidjson/python-rapidjson/blob/master/LICENSE
Upstream Changelog: https://github.com/python-rapidjson/python-rapidjson/blob/master/CHANGES.rst
Upstream setup.py:  https://github.com/python-rapidjson/python-rapidjson/blob/v1.5/setup.py

Actions:
1. No actions

Result:
- all-succeeded