### PR TITLE
Update recipe for py313_codesign

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,1 +1,0 @@
-python %SRC_DIR%\setup.py install --rj-include-dir=%LIBRARY_PREFIX%\include  --single-version-externally-managed --record record.txt

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,1 +1,0 @@
-python $SRC_DIR/setup.py install --rj-include-dir=$PREFIX/include  --single-version-externally-managed --record record.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   # This package isn't included in the SOW Packages.
   # Also there isn't rapidjson==1.1.0 on s390x
   skip: True  # [py36 or s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "python-rapidjson" %}
-{% set version = "1.5" %}
-{% set sha256 = "04323e63cf57f7ed927fd9bcb1861ef5ecb0d4d7213f2755969d4a1ac3c2de6f" %}
+{% set version = "1.20" %}
+{% set sha256 = "115f08c86d2df7543c02605e77c84727cdabc4b08310d2f097e953efeaaa73eb" %}
 {% set rapidjson_version = "1.1.0" %}
 
 package:
@@ -9,14 +9,14 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/python_rapidjson-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   # This package isn't included in the SOW Packages.
-  # Also there isn't rapidjson==1.1.0 on s390x
-  skip: True  # [py36 or s390x]
+  skip: True  # [py38 or s390x]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   build:
@@ -27,7 +27,7 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - rapidjson =={{ rapidjson_version }}
+    - packaging
   run:
     - python
 


### PR DESCRIPTION
Rebuild for codesigned win-64 py313 artifacts.

update to 1.20
https://github.com/python-rapidjson/python-rapidjson/tree/v1.20